### PR TITLE
Support version pydocstyle 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 
 setup(
     name='pre-commit-mirrors-pydocstyle',
-    version='0.0.0',
-    install_requires=['pydocstyle==1.0.0'],
+    version='2.0.0',
+    install_requires=['pydocstyle==2.0.0'],
 )


### PR DESCRIPTION
Also increases the version of the pre-commit hook to match the pydocstyle version for reference.